### PR TITLE
Add word "recursive" to core forth

### DIFF
--- a/eforth.forth
+++ b/eforth.forth
@@ -273,8 +273,8 @@
     swap ! 
     cell- np ! ; 
 : : token $,n postpone ] ; 
-: ; compile exit postpone [ overt ; immediate
-: recursive last @ current @ ! ; immediate
+: ; compile exit postpone [ overt ; immediate 
+: recursive last @ current @ ! ; immediate 
 : recurse last @ code> @ , ; immediate 
 : dovar r> ; 
 : create token $,n compile dovar overt ; 

--- a/eforth.forth
+++ b/eforth.forth
@@ -274,7 +274,7 @@
     cell- np ! ; 
 : : token $,n postpone ] ; 
 : ; compile exit postpone [ overt ; immediate
-: recursive last @ CURRENT @ ! ; immediate
+: recursive last @ current @ ! ; immediate
 : recurse last @ code> @ , ; immediate 
 : dovar r> ; 
 : create token $,n compile dovar overt ; 

--- a/eforth.forth
+++ b/eforth.forth
@@ -273,7 +273,8 @@
     swap ! 
     cell- np ! ; 
 : : token $,n postpone ] ; 
-: ; compile exit postpone [ overt ; immediate 
+: ; compile exit postpone [ overt ; immediate
+: recursive last @ CURRENT @ ! ; immediate
 : recurse last @ code> @ , ; immediate 
 : dovar r> ; 
 : create token $,n compile dovar overt ; 


### PR DESCRIPTION
Since there are two ways of creating a recursive word, either by including the word "recursive" in the definition or using the word "recurse" as a placeholder for it's own name, both words should be included.

Specifically, the "recursive" word allows for recursion, but would disallow referencing a previous definition of the word currently being defined. Whereas "recurse" would allow you to mix references to previous (by using its actual name) and the current (using "recurse").